### PR TITLE
Introduce firejail

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: run
 run:
-	go run main.go
+	firejail --seccomp.enotsup=sendfile go run main.go
 
 .PHONY: migrate
 migrate:

--- a/vagrant/provision.sh
+++ b/vagrant/provision.sh
@@ -13,6 +13,7 @@ install_required_packages() {
     sudo apt-get install -y \
 	ack-grep \
         dos2unix \
+	firejail \
 	git \
 	htop \
 	make \


### PR DESCRIPTION
Vagrant/VirtualBox doesn't play nicely with Go. We tried this workaround:
https://github.com/wader/disable_sendfile_vbox_linux but it didn't work,
and in the end opted for this:
https://stackoverflow.com/questions/20702221/http-fileserver-caching-files-and-serving-old-versions-after-edit/32590282#32590282