### PR TITLE
Fix vagrant provision install realize go package

### DIFF
--- a/vagrant/provision.sh
+++ b/vagrant/provision.sh
@@ -68,7 +68,7 @@ install_golang_1_10_5() {
 }
 
 install_realize_go_package() {
-    go get github.com/oxequa/realize
+    run_as_vagrant "go get github.com/oxequa/realize"
 }
 
 create_postgresql_database_and_user() {
@@ -100,6 +100,7 @@ install_required_packages
 install_postgresql_10
 install_golang_1_10_5
 create_postgresql_database_and_user
+install_realize_go_package
 migrate_database
 
 set +x


### PR DESCRIPTION
Thanks for adding realize!

Two things:

* provision runs as root by default, so we have to forcibly run it as
vagrant (with the `run_as_vagrant` helper)

* you made the function but didn't call it :P

The provision stuff is quite fiddly: it's well worth testing this stuff
each time by uninstalling the thing nad trying out `vagrant provision`
to make sure it works as you expect (or use `vagrant destroy` to be
really sure)